### PR TITLE
Fix heterogen-fuzz throwing segfault due to missing good-outputs folder

### DIFF
--- a/2-test-generation/readme.md
+++ b/2-test-generation/readme.md
@@ -30,4 +30,6 @@ Go back to the `2-test-generation` folder, type the following command:
 ```bash
 ./heterogen-fuzz good-seeds/ good-outputs/ 1000 ../test-program/a.out
 ```
+Make sure output folder exists before using heterogen-fuzz.
+
 You can find the generated test inputs in `good-outputs` folder. The generated inputs will be used to check behavior preservation in the automated code edit process. This step generates the results presented in Table 4. Please note that fuzzing is a random test generation process; thus, the results vary significantly across different runs.


### PR DESCRIPTION
Currently, the `good-outputs` folder must be manually created before generating tests or the program will fail with segmentation fault. This pull request documents such behavior and adds an empty `good-outputs` folder to the repository.